### PR TITLE
Fix kmod-ipt-ipopt module compilation error

### DIFF
--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -328,6 +328,7 @@ $(eval $(call KernelPackage,ipt-offload))
 define KernelPackage/ipt-ipopt
   TITLE:=Modules for matching/changing IP packet options
   KCONFIG:=$(KCONFIG_IPT_IPOPT)
+  DEPENDS:=+PACKAGE_kmod-nf-conntrack:kmod-nf-conntrack
   FILES:=$(foreach mod,$(IPT_IPOPT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(IPT_IPOPT-m)))
   $(call AddDepends/ipt)


### PR DESCRIPTION
This change fixes the following issue
____________________________________________________

Package kmod-ipt-ipopt is missing dependencies for the following libraries: nf_conntrack.ko
make[2]: *** [modules/netfilter.mk:352: /home/asvio/02-R7800/02-main-nss/bin/targets/ipq806x/generic/packages/kmod-ipt-ipopt-6.6.79-r1.apk] Error 1 make[2]: Leaving directory '/home/asvio/02-R7800/02-main-nss/package/kernel/linux' time: package/kernel/linux/compile#2.95#3.11#5.35
    ERROR: package/kernel/linux failed to build.
make[1]: *** [package/Makefile:189: package/kernel/linux/compile] Error 1 make[1]: Leaving directory '/home/asvio/02-R7800/02-main-nss' make: *** [/home/asvio/02-R7800/02-main-nss/include/toplevel.mk:233: package/linux/compile] Error 2

