### PR TITLE
Fix broken CFI patch...

### DIFF
--- a/target/linux/ipq806x/patches-6.6/990-0012-qca-nss-cfi-support.patch
+++ b/target/linux/ipq806x/patches-6.6/990-0012-qca-nss-cfi-support.patch
@@ -1,9 +1,11 @@
 --- a/crypto/authenc.c
 +++ b/crypto/authenc.c
-@@ -415,6 +415,8 @@ static int crypto_authenc_create(struct
+@@ -415,6 +415,10 @@ static int crypto_authenc_create(struct
  		     enc->base.cra_driver_name) >= CRYPTO_MAX_ALG_NAME)
  		goto err_free_inst;
  
++	// inst->alg.base.cra_flags = (auth_base->cra_flags |
++ 	//			    enc->base.cra_flags) & CRYPTO_ALG_ASYNC;
 +	inst->alg.base.cra_flags |= (auth_base->cra_flags |
 +				    enc->base.cra_flags) & CRYPTO_ALG_NOSUPP_SG;
  	inst->alg.base.cra_priority = enc->base.cra_priority * 10 +
@@ -23,6 +25,18 @@
   * The algorithm may allocate memory during request processing, i.e. during
   * encryption, decryption, or hashing.  Users can request an algorithm with this
   * flag unset if they can't handle memory allocation failures.
+@@ -462,6 +467,11 @@ static inline const char *crypto_tfm_alg
+ 	return tfm->__crt_alg->cra_driver_name;
+ }
+ 
++static inline u32 crypto_tfm_alg_flags(struct crypto_tfm *tfm)
++{
++	return tfm->__crt_alg->cra_flags & ~CRYPTO_ALG_TYPE_MASK;
++}
++
+ static inline unsigned int crypto_tfm_alg_blocksize(struct crypto_tfm *tfm)
+ {
+ 	return tfm->__crt_alg->cra_blocksize;
 --- a/net/ipv4/esp4.c
 +++ b/net/ipv4/esp4.c
 @@ -657,6 +657,7 @@ static int esp_output(struct xfrm_state
@@ -37,7 +51,7 @@
  	aead = x->data;
  	alen = crypto_aead_authsize(aead);
  
-+	nosupp_sg = crypto_tfm_alg_type(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
++	nosupp_sg = crypto_tfm_alg_flags(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
 +	if (nosupp_sg && skb_linearize(skb)) {
 +		return -ENOMEM;
 +	}
@@ -57,7 +71,7 @@
  	if (elen <= 0)
  		goto out;
  
-+	nosupp_sg = crypto_tfm_alg_type(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
++	nosupp_sg = crypto_tfm_alg_flags(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
 +	if (nosupp_sg && skb_linearize(skb)) {
 +		err = -ENOMEM;
 +		goto out;
@@ -80,7 +94,7 @@
  	aead = x->data;
  	alen = crypto_aead_authsize(aead);
  
-+	nosupp_sg = crypto_tfm_alg_type(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
++	nosupp_sg = crypto_tfm_alg_flags(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
 +	if (nosupp_sg && skb_linearize(skb)) {
 +		return -ENOMEM;
 +	}
@@ -100,7 +114,7 @@
  		goto out;
  	}
  
-+	nosupp_sg = crypto_tfm_alg_type(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
++	nosupp_sg = crypto_tfm_alg_flags(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
 +	if (nosupp_sg && skb_linearize(skb)) {
 +		ret = -ENOMEM;
 +		goto out;


### PR DESCRIPTION
This change fixes the following error

```
# CC [M]  net/ipv4/esp4.o
  arm-openwrt-linux-muslgnueabi-gcc -Wp,-MMD,net/ipv4/.esp4.o.d -nostdinc -I./arch/arm/include -I./arch/arm/include/generated  -I./include -I./arch/arm/include/uapi -I./arch/arm/include/generated/uapi -I./include/uapi -I./include/generated/uapi -include ./include/linux/compiler-version.h -include ./include/linux/kconfig.h -include ./include/linux/compiler_types.h -D__KERNEL__ -mlittle-endian -D__LINUX_ARM_ARCH__=7 -fmacro-prefix-map=./= -Werror -std=gnu11 -fshort-wchar -funsigned-char -fno-common -fno-PIE -fno-strict-aliasing -fno-dwarf2-cfi-asm -mno-fdpic -fno-ipa-sra -mtp=cp15 -mabi=aapcs-linux -mfpu=vfp -funwind-tables -marm -Wa,-mno-warn-deprecated -march=armv7-a -msoft-float -Uarm -fno-delete-null-pointer-checks -O2 -fno-allow-store-data-races -fstack-protector -fomit-frame-pointer -fno-stack-clash-protection -fstrict-flex-arrays=3 -fno-strict-overflow -fno-stack-check -fconserve-stack -Wall -Wundef -Werror=implicit-function-declaration -Werror=implicit-int -Werror=return-type -Werror=strict-prototypes -Wno-format-security -Wno-trigraphs -Wno-frame-address -Wno-address-of-packed-member -Wframe-larger-than=1024 -Wno-main -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-dangling-pointer -Wvla -Wno-pointer-sign -Wcast-function-type -Wno-array-bounds -Wno-alloc-size-larger-than -Wimplicit-fallthrough=5 -Werror=date-time -Werror=incompatible-pointer-types -Werror=designated-init -Wenum-conversion -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-restrict -Wno-packed-not-aligned -Wno-format-overflow -Wno-format-truncation -Wno-stringop-overflow -Wno-stringop-truncation -Wno-missing-field-initializers -Wno-type-limits -Wno-shift-negative-value -Wno-maybe-uninitialized -Wno-sign-compare -g -fno-var-tracking -femit-struct-debug-baseonly -fmacro-prefix-map=/home/user/mnt/sdb1/.owrt/r7800-nss/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi=target-arm_cortex-a15+neon-vfpv4_musl_eabi -fno-caller-saves  -DMODULE  -DKBUILD_BASENAME='"esp4"' -DKBUILD_MODNAME='"esp4"' -D__KBUILD_MODNAME=kmod_esp4 -c -o net/ipv4/esp4.o net/ipv4/esp4.c  
net/ipv4/esp4.c: In function 'esp_output':
net/ipv4/esp4.c:672:21: error: implicit declaration of function 'crypto_tfm_alg_type'; did you mean 'crypto_tfm_alg_name'? [-Werror=implicit-function-declaration]
  672 |         nosupp_sg = crypto_tfm_alg_type(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
      |                     ^~~~~~~~~~~~~~~~~~~
      |                     crypto_tfm_alg_name
cc1: all warnings being treated as errors
make[9]: *** [scripts/Makefile.build:243: net/ipv4/esp4.o] Error 1
make[8]: *** [scripts/Makefile.build:480: net/ipv4] Error 2
make[7]: *** [scripts/Makefile.build:480: net] Error 2
make[6]: *** [/home/user/mnt/sdb1/.owrt/r7800-nss/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-ipq806x_generic/linux-6.6.83/Makefile:1921: .] Error 2
make[5]: *** [Makefile:234: __sub-make] Error 2
make[5]: Leaving directory '/home/user/mnt/sdb1/.owrt/r7800-nss/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-ipq806x_generic/linux-6.6.83'
make[4]: *** [Makefile:27: /home/user/mnt/sdb1/.owrt/r7800-nss/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-ipq806x_generic/linux-6.6.83/.modules] Error 2
make[4]: Leaving directory '/home/user/mnt/sdb1/.owrt/r7800-nss/target/linux/ipq806x'
make[3]: *** [Makefile:12: compile] Error 2
make[3]: Leaving directory '/home/user/mnt/sdb1/.owrt/r7800-nss/target/linux'
time: target/linux/compile#10.98#4.84#15.72
    ERROR: target/linux failed to build.
make[2]: *** [target/Makefile:32: target/linux/compile] Error 1
make[2]: Leaving directory '/home/user/mnt/sdb1/.owrt/r7800-nss'
make[1]: *** [target/Makefile:25: /home/user/mnt/sdb1/.owrt/r7800-nss/staging_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/stamp/.target_compile] Error 2
make[1]: Leaving directory '/home/user/mnt/sdb1/.owrt/r7800-nss'
make: *** [/home/user/mnt/sdb1/.owrt/r7800-nss/include/toplevel.mk:233: world] Error 2
```
